### PR TITLE
fix: improve entries tag feedback

### DIFF
--- a/src/routes/user/entries/new/+page.svelte
+++ b/src/routes/user/entries/new/+page.svelte
@@ -41,6 +41,7 @@
 	let url = $state("");
 	let invalidTags = $derived(new SvelteSet(tags).intersection(new Set(levels)).size === 0);
 	let newtag: HTMLInputElement | undefined = $state();
+	let showInvalidTagsMessage = $state(false);
 
 	$effect(() => {
 		// The level was not provided
@@ -220,6 +221,7 @@
 							if (tags.includes(level)) {
 								tags = tags.filter((t) => t !== level);
 							} else {
+								showInvalidTagsMessage = true;
 								tags.push(level);
 							}
 						}}
@@ -241,6 +243,7 @@
 				onkeydown={(event) => {
 					if (event.key === "Enter" || event.key === ",") {
 						if (tag.length) {
+							showInvalidTagsMessage = true;
 							tags.push(slugify(tag));
 							tag = "";
 
@@ -250,7 +253,7 @@
 				}}
 			/>
 
-			{#if invalidTags && tags.length > 0}
+			{#if invalidTags && showInvalidTagsMessage}
 				<span id="newtag-error" class="error-message">{invalidTagsMessage}</span>
 			{/if}
 		</div>

--- a/src/routes/user/entries/update/[entryUid=uuid]/+page.svelte
+++ b/src/routes/user/entries/update/[entryUid=uuid]/+page.svelte
@@ -44,6 +44,7 @@
 	let tags: string[] = $state(data.tags);
 	let invalidTags = $derived(new SvelteSet(tags).intersection(new Set(levels)).size === 0);
 	let newtag: HTMLInputElement | undefined = $state();
+	let showInvalidTagsMessage = $state(false);
 
 	$effect(() => {
 		// The level was not provided
@@ -224,6 +225,7 @@
 								tags = tags.filter((t) => t !== level);
 							} else {
 								tags.push(level);
+								showInvalidTagsMessage = true;
 							}
 						}}
 					>
@@ -244,6 +246,7 @@
 				onkeydown={(event) => {
 					if (event.key === "Enter" || event.key === ",") {
 						if (tag.length) {
+							showInvalidTagsMessage = true;
 							tags.push(slugify(tag));
 							tag = "";
 
@@ -253,7 +256,7 @@
 				}}
 			/>
 
-			{#if invalidTags && tags.length > 0}
+			{#if invalidTags && showInvalidTagsMessage}
 				<span id="newtag-error" class="error-message">{invalidTagsMessage}</span>
 			{/if}
 		</div>


### PR DESCRIPTION
Display the "pick level tag" error message when the user has interacted with the tag input and the tags are invalid 