### PR TITLE
feat: add feedback for usernames availability

### DIFF
--- a/src/routes/api/check-username/fetch.ts
+++ b/src/routes/api/check-username/fetch.ts
@@ -1,43 +1,52 @@
 import { debounce } from "@fcrozatier/ts-helpers";
 
 let controller: AbortController | null = null;
-let usernameStatus: "pending" | "available" | "taken" | "error" | undefined = $state(undefined);
+export type UsernameStatus = "pending" | "available" | "taken" | "error" | undefined;
 
-export const checkUsername = debounce(async (username: string) => {
+const checkUsername = debounce(
+	async (
+		username: string,
+		setStatus: (status: UsernameStatus) => void,
+	) => {
+		controller = new AbortController();
+		const signal = controller.signal;
+
+		try {
+			const r = await fetch("/api/check-username", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({ username }),
+				signal,
+			});
+
+			const data = (await r.json()) as {
+				valid: boolean;
+				status: "available" | "taken";
+			};
+
+			controller = null;
+
+			if (!data.valid) setStatus("error");
+			else return setStatus(data.status);
+		} catch (error) {
+			if (!(error instanceof DOMException && error.name === "AbortError")) {
+				return setStatus("error");
+			}
+		}
+	},
+	1000,
+);
+
+export async function resetUsernameStatus(
+	username: string,
+	setStatus: (status: UsernameStatus) => void,
+) {
+	setStatus("pending");
+
 	if (controller) {
 		controller.abort();
 	}
-
-	controller = new AbortController();
-	const signal = controller.signal;
-
-	try {
-		console.log("checking username");
-		usernameStatus = "pending";
-		const r = await fetch("/api/check-username", {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({ username }),
-			signal,
-		});
-
-		const data = (await r.json()) as {
-			valid: boolean;
-			status: "available" | "taken";
-		};
-
-		if (!data.valid) usernameStatus = "error";
-		else usernameStatus = data.status;
-
-		console.log(usernameStatus);
-		controller = null;
-	} catch (error) {
-		if (error instanceof DOMException && error.name === "AbortError") {
-			console.log(error.name, error.message);
-		} else {
-			throw error;
-		}
-	}
-}, 1000);
+	checkUsername(username, setStatus);
+}


### PR DESCRIPTION
Instant feedback is now provided for usernames in the signup page and when linking coauthors when submiting/updating entries