### PR TITLE
fix: show the inactive badge on deactivated entries

### DIFF
--- a/src/routes/user/entries/+page.svelte
+++ b/src/routes/user/entries/+page.svelte
@@ -95,7 +95,7 @@
 									{/if}
 									{#if data.strike?.entry_uid === uid && data.strike?.state === ENTRY_STATE.WaitingForReview}
 										<span>under review</span>
-									{:else if state === ENTRY_STATE.Inactive && data.strike?.entry_uid === uid}
+									{:else if state === ENTRY_STATE.Inactive}
 										<span>inactive</span>
 									{/if}
 								</div>


### PR DESCRIPTION
Fixes #192.

## Problem

The `inactive` badge on **My entries** never renders. A creator whose entry has been deactivated sees no status at all — the entry looks identical to an active one, and the only signal is the `Entry disabled` email.

The guard at `src/routes/user/entries/+page.svelte:98` requires both `state === ENTRY_STATE.Inactive` and a matching `data.strike`. That conjunction is unsatisfiable, for two independent reasons:

1. The loader's strike query filters `entries.state in ('action_required', 'waiting_for_review')`, which excludes `'inactive'`. If a strike row comes back for an entry, that entry is not `inactive`; if it is `inactive`, no row comes back.
2. It also filters `strikes.state = 'open'`, but deactivation closes every strike on the entry in the same handler that sets the state (`admin/strikes/+page.server.ts:191-200`, `admin/flagged/+page.server.ts:151-161`).

## Fix

Reverts the one-line change in adbb59d (#186). `state` already comes from the user's own entries query, which has no state filter, so the strike check was redundant as well as unsatisfiable.

The stated intent of #186 was to show the flag "only when there are issues". Every path that writes `inactive` is already an admin moderation action — deactivate in `admin/strikes`, both paths in `admin/flagged`, and `admin/users/ban`. The schema default is `active` and nothing in the migrations or the algo queries writes the state, so there is no benign `inactive` for the extra condition to suppress. If #186 was working around something I haven't found, I'm happy to rework this as a narrower condition instead.

The sibling branches are untouched and unaffected: `action_required` and `waiting_for_review` both keep their strike open and are both in the `in` list, so "under review" and the alert banner still behave as before.

## Not included

Two things noted in #192 that felt out of scope for a one-line regression fix, happy to add either:

- The badge renders as a bare `<span>`, with none of the visual weight of the admin status dots.
- The strike query's `limit 1` means a creator with several affected entries gets the banner and badges driven only by their most recent strike.

## Testing

Verified by reading the deactivation handlers and the loader query; the diff is a byte-exact revert of adbb59d, and git confirms the blob hash returns to its pre-adbb59d value. I did not run `pnpm check` — I don't have a pnpm/Node 24 toolchain set up for this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2h9B8crvA3dhJn9KemGA1